### PR TITLE
Clarify attachBaseContext() usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ no default font and use the default attribute of `R.id.fontPath`._
 Wrap the `Activity` Context:
 
 ```java
-@Override
-protected void attachBaseContext(Context newBase) {
-    super.attachBaseContext(CalligraphyContextWrapper.wrap(newBase));
+public class MyActivity extends Activity {
+    // ...
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(CalligraphyContextWrapper.wrap(newBase));
+    }
+    // ...
 }
 ```
 


### PR DESCRIPTION
Make it impossible to miss that it is the Activity that should be targeted with `attachBaseContext()`, even when just skimming the usage instructions.

After having installed default font according to the instructions I just tried overriding the `attachBaseContext()` in the same file (my `Application` class) and since it existed I did not think twice about it. Then it took me a while before finally figuring out that it should be done in my `Activity` class.

This pull request updates the documentation with example code that explicitly shows that it is the `attachBaseContext()` in the `Activity` that should be overriden, not the one in `Application`.